### PR TITLE
Implement cleanup function for simulations

### DIFF
--- a/boss/BOSS.py
+++ b/boss/BOSS.py
@@ -59,7 +59,7 @@ def main(arg_list: list = None):
             func = exp.process_batch_aeons_sim
         # launch main loop
         exp.init_sim()
-        while exp.batch <= args.maxb:
+        while exp.batch < args.maxb:
             exp.process_batch_sim(func)
         exp.cleanup()
 

--- a/boss/runs/core.py
+++ b/boss/runs/core.py
@@ -143,11 +143,15 @@ class BossRuns(Boss):
 
     def cleanup(self) -> None:
         """
-        To be implemented
+        Dump remaining batches to file before simulation ends
 
         :return:
         """
-        pass
+        for cond in ('control', 'boss'):
+            curr_time = getattr(self.read_cache, f'time_{cond}')
+            dump_number = getattr(self.read_cache, f'dump_n_{cond}')
+            cache = getattr(self.read_cache, f'cache_{cond}')
+            self.read_cache._execute_dump(cond=cond, dump_number=dump_number, cache=cache)
 
 
     def update_wrapper(self) -> None:


### PR DESCRIPTION
I propose two changes to the simulation mode to align it better with expected behaviour. 

The first unexpected behaviour concerns the last few batches generated at the end of the simulation. The total number of batches is unlikely to perfectly fit into a multiple of the dumptime, causing a small number of batches to be "left over" at the end of the simulation. These are not written to file because they do not exceed the dumptime. I believe this could cause confusion why the full number of reads falls below the expected number and can affect case and control differently.
To combat this, I have implemented the `cleanup` function executed at the very end of the simulation mode. My proposed implementation simply takes the caches for boss and control and writes them to a final output file using the `_execute_dump` method of the `ReadCache` class. If a user is only concerned with the amount of time spent by each condition, they have the option of disregarding the final output file for their downstream analyses.

The second unexpected behaviour concers the maximum batch number. The initial batch number is 0 and the loop is executed until the batch number exceeds the maximum batch number, resulting in maximum batch number + 1 batches (e.g. 201 instead of the specified 200).
I suggest solving this mismatch by replacing the `<=` with a `<` sign, so that the last iteration is executed before exceeding the maximum batch number.