### PR TITLE
Barcodes bug fix

### DIFF
--- a/boss/batch.py
+++ b/boss/batch.py
@@ -206,7 +206,7 @@ class ReadCache:
 
 
 
-    def fill_cache(self, read_sequences: dict[str, str], reads_decision: dict[str, str]) -> None:
+    def fill_cache(self, read_sequences: dict[str, str], reads_decision: dict[str, str], reads_barcodes: dict[str, str]=None) -> None:
         """
         Write batches of simulated reads for convenient processing after the experiment
         Either only adds reads to a cache, or dumps them to file if it's time
@@ -219,9 +219,17 @@ class ReadCache:
         def add_to_cache(seqs, cache):
             for rid, seq in seqs.items():
                 cache[rid] = seq
+
+        def add_to_cache_bc(seqs, cache, barcodes):
+            for rid, seq in seqs.items():
+                cache[rid+".barcode=barcode"+str(barcodes[rid]).zfill(2)] = seq
         # add the current sequences to the cache
-        add_to_cache(seqs=read_sequences, cache=self.cache_control)
-        add_to_cache(seqs=reads_decision, cache=self.cache_boss)
+        if reads_barcodes is None:
+            add_to_cache(seqs=read_sequences, cache=self.cache_control)
+            add_to_cache(seqs=reads_decision, cache=self.cache_boss)
+        else:
+            add_to_cache_bc(seqs=read_sequences, cache=self.cache_control, barcodes=reads_barcodes)
+            add_to_cache_bc(seqs=reads_decision, cache=self.cache_boss, barcodes=reads_barcodes)
         # check if time to dump and execute
         self._prep_dump(cond='control')
         self._prep_dump(cond='boss')

--- a/boss/batch.py
+++ b/boss/batch.py
@@ -265,18 +265,12 @@ class ReadCache:
         """
         logging.info(f'dump {cond} #{dump_number}. # of reads {len(list(cache.keys()))}')
         filename = f'00_reads/{cond}_{dump_number}.fa'
-        # copy previous file to make cumulative
-        previous_filename = f'00_reads/{cond}_{dump_number - 1}.fa'
-        try:
-            execute(f"cp {previous_filename} {filename}")
-        except FileNotFoundError:
-            # at the first batch, create empty 0th and copy to 1st file
-            # to make sure we don't append to the same file multiple times
-            # otherwise we have duplicate reads causing issues
+        # at the first batch, create empty 0th file
+        if dump_number == 1:
+            previous_filename = f'00_reads/{cond}_{dump_number - 1}.fa'
             empty_file(previous_filename)
-            execute(f"cp {previous_filename} {filename}")
         # writing operation
-        with open(filename, "a") as f:
+        with open(filename, "w+") as f:
             for rid, seq in cache.items():
                 r = random_id()
                 fa_line = f'>{rid}.{r}\n{seq}\n'

--- a/boss/runs/core.py
+++ b/boss/runs/core.py
@@ -138,8 +138,13 @@ class BossRuns(Boss):
             cstrat = strat[i: i + cont.length // window, :]
             assert cstrat.shape == cont.strat.shape
             # assign new strat
-            for b in range(0, len(self.args.barcodes)):
-                cont.strat[buckets[:,b], :, b] = cstrat[buckets[:,b], :,b]
+            for bc_name in self.args.barcodes:
+                if self.args.barcodes[0] == '':
+                    b = 0
+                    cont.strat[buckets[:,b], :, b] = cstrat[buckets[:,b], :,b]
+                else:
+                    b = self.barcodes_index[int(bc_name.split('barcode')[1])]
+                    cont.strat[buckets[:,b], :, b] = cstrat[buckets[:,b], :,b]
             # log number of accepted sites
             f_perc = np.count_nonzero(cont.strat[:, 0]) / cont.strat.shape[0]
             r_perc = np.count_nonzero(cont.strat[:, 1]) / cont.strat.shape[0]

--- a/boss/runs/reference.py
+++ b/boss/runs/reference.py
@@ -204,7 +204,7 @@ class Contig:
             states = len(switch_count)
             # log the first time a contig's strategy is switched on
             if states == 2 and not all(self.switched_on):
-                self.switched_on[self.switched_on] = True
+                self.switched_on[np.logical_not(self.switched_on)] = True
                 logging.info(f"Activated strategy for: {self.name}") # TODO: Add barcode to this log
             
             self.coverage[:,:,b] = coverage

--- a/boss/runs/simulation.py
+++ b/boss/runs/simulation.py
@@ -141,9 +141,9 @@ class BossRunsSim(BossRuns):
         :return:
         """
         # trigger the sampling of reads and their mappings
-        read_seqs, read_quals, read_barcodes, paf_f, paf_t = self.sampler.sample()
+        read_seqs, read_quals, read_barcodes_names, paf_f, paf_t = self.sampler.sample()
         # Convert barcodes to index
-        read_barcodes = {rid: self.barcodes_index.get(bc, 0) for rid, bc in read_barcodes.items()}
+        read_barcodes = {rid: self.barcodes_index.get(bc, 0) for rid, bc in read_barcodes_names.items()}
         # make decisions and generate the paf_dict
         paf_dict, reads_decision, n_mapped, n_unmapped, n_accepted, n_rejected = (
             self.make_decisions(seqs=read_seqs,
@@ -173,7 +173,11 @@ class BossRunsSim(BossRuns):
             reads_decision=reads_decision,
             n_reject=n_rejected
         )
-        self.read_cache.fill_cache(read_sequences=self.sampler.fq_stream.read_sequences, reads_decision=reads_decision)
+        if self.args.barcodes[0] == "":
+            self.read_cache.fill_cache(read_sequences=self.sampler.fq_stream.read_sequences, reads_decision=reads_decision)
+        else:
+            self.read_cache.fill_cache(read_sequences=self.sampler.fq_stream.read_sequences, reads_decision=reads_decision, 
+            reads_barcodes=read_barcodes_names)
         # update wrapper of superclass
         self.update_wrapper()
 

--- a/boss/runs/simulation.py
+++ b/boss/runs/simulation.py
@@ -192,7 +192,8 @@ class BossRunsSim(BossRuns):
         for cond in ('control', 'boss'):
             dump_number = getattr(self.read_cache, f'dump_n_{cond}')
             cache = getattr(self.read_cache, f'cache_{cond}')
-            self.read_cache._execute_dump(cond=cond, dump_number=dump_number, cache=cache)
+            if len(list(cache.keys())) > 0:  # don't dump empty file
+                self.read_cache._execute_dump(cond=cond, dump_number=dump_number, cache=cache)
 
 
 


### PR DESCRIPTION
When running a larger simulated experiment with the new barcodes feature, I noticed two issues. 

First, I had introduced a bug in how the strategies were turned on, so they were actually never turned on. And second, the barcode information was not output to the resulting fasta files, which limited the analysis of the results.

The two commits here should address these issues. The plan is to keep this pull request small which just these two commits, and then create other ones when I have implemented unit tests and barcodes in the live version.